### PR TITLE
Invopop and GOBL structs for Envelopes resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'gobl', git: 'https://github.com/invopop/gobl.ruby.git', branch: 'main'
+# TODO: `gobl` is now a runtime dependency of the gem. This entry needs to be moved to the
+# gemspec as soon as `gobl.ruby` is published to rubygems
+gem 'gobl', github: 'invopop/gobl.ruby', branch: 'main'
+
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 gem 'rubocop', '~> 1.21'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/invopop/gobl.ruby.git
-  revision: fb33ee2ddeff697feea596a5f78b1c65b8fed887
+  revision: 20817bad42107bc893c71c85d6a3ec1339cb9e56
   branch: main
   specs:
     gobl (0.1.0)
@@ -16,10 +16,13 @@ PATH
   specs:
     invopop (0.1.0)
       faraday (~> 2.5)
+      hashme (~> 0.2.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (6.1.7)
+      activesupport (= 6.1.7)
     activesupport (6.1.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -57,6 +60,8 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.0)
     hashdiff (1.0.1)
+    hashme (0.2.6)
+      activemodel (>= 4.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)

--- a/invopop.gemspec
+++ b/invopop.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'faraday', '~> 2.5'
+  spec.add_dependency 'hashme', '~> 0.2.6'
 end

--- a/lib/invopop.rb
+++ b/lib/invopop.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
 
 require 'faraday'
+require 'gobl'
+require 'hashme'
+
+require_relative 'invopop/extensions/gobl'
+require_relative 'invopop/extensions/hashme'
 
 require_relative 'invopop/client'
 require_relative 'invopop/connection'
 require_relative 'invopop/namespace'
 require_relative 'invopop/resource'
 require_relative 'invopop/silo'
+require_relative 'invopop/silo/attachment'
+require_relative 'invopop/silo/envelope'
+require_relative 'invopop/silo/envelope_collection'
 require_relative 'invopop/silo/envelopes'
 require_relative 'invopop/transform'
 require_relative 'invopop/transform/jobs'

--- a/lib/invopop/extensions/gobl.rb
+++ b/lib/invopop/extensions/gobl.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+raise 'The `gobl` library version has changed. Review if this extension still applies' if GOBL::VERSION != '0.1.0'
+
+# Temporary extensions for the `gobl` gem. To be removed when the library supports them.
+module GOBL
+  module Org
+    # Extends Meta to allow to be instantiated from a hash. This is necessary for Hashme
+    # to instantiate a property of this type.
+    class Meta
+      def self.new(value)
+        if value.is_a?(Hash) && value.keys.map(&:to_s) != %w[_value]
+          super _value: value
+        else
+          super
+        end
+      end
+    end
+  end
+
+  # Extends Envelope to allow to be instantiated from a hash. This is necessary for Hashme
+  # to instantiate a property of this type.
+  class Envelope
+    def self.new(attrs)
+      if attrs.key?('$schema')
+        from_gobl! attrs
+      else
+        super
+      end
+    end
+  end
+end

--- a/lib/invopop/extensions/hashme.rb
+++ b/lib/invopop/extensions/hashme.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+raise 'The `hashme` library version has changed. Review if this extension still applies' if Hashme::VERSION != '0.2.6'
+
+# Temporary extensions for the `hashme` gem. To be removed when the library supports them.
+module Hashme
+  # Adds an URI helper class to the Hashme namespace so that properties referencing them
+  # typecast to URI objects in Ruby standard library.
+  class URI
+    def self.new(value)
+      URI(value)
+    end
+  end
+
+  # TrueClass typecasts to a boolean in Hashme. We alias it to `Boolean` for clarity.
+  Boolean = TrueClass
+end

--- a/lib/invopop/silo/attachment.rb
+++ b/lib/invopop/silo/attachment.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Invopop
+  class Silo
+    class Attachment
+      include Hashme
+
+      property :id, String
+      property :created_at, Time
+
+      property :name, String
+      property :desc, String
+      property :hash, String
+      property :mime, String
+      property :size, Integer
+      property :stored, Boolean
+      property :url, URI
+
+      property :meta, Hash
+    end
+  end
+end

--- a/lib/invopop/silo/envelope.rb
+++ b/lib/invopop/silo/envelope.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Invopop
+  class Silo
+    class Envelope
+      include Hashme
+
+      property :id, String
+      property :created_at, Time
+      property :updated_at, Time
+
+      property :env_schema, String
+      property :doc_schema, String
+      property :digest, String
+      property :tags, [String]
+      property :meta, GOBL::Org::Meta
+      property :draft, Boolean
+
+      property :attachments, [Attachment]
+      property :data, GOBL::Envelope
+    end
+  end
+end

--- a/lib/invopop/silo/envelope_collection.rb
+++ b/lib/invopop/silo/envelope_collection.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Invopop
+  class Silo
+    class EnvelopeCollection
+      include Hashme
+
+      property :list, [Envelope]
+      property :limit, Integer
+      property :created_at, String
+      property :next_created_at, String
+    end
+  end
+end

--- a/lib/invopop/silo/envelopes.rb
+++ b/lib/invopop/silo/envelopes.rb
@@ -10,6 +10,22 @@ module Invopop
       def uri_fragment
         '/envelopes'
       end
+
+      def fetch(*args)
+        if single_resource?
+          Envelope.new(super)
+        else
+          EnvelopeCollection.new(super)
+        end
+      end
+
+      def create(*args)
+        Envelope.new(super)
+      end
+
+      def update(*args)
+        Envelope.new(super)
+      end
     end
   end
 end

--- a/mage.go
+++ b/mage.go
@@ -19,7 +19,7 @@ func Setup() error {
 
 // Runs gem's rspec tests.
 func Spec() error {
-	return dockerRunCmd(name, "", "rake", "spec")
+	return dockerRunCmd(name, "", "bundle", "exec", "rake", "spec")
 }
 
 // Runs an interactive shell within a docker container.

--- a/spec/invopop/silo/attachment_spec.rb
+++ b/spec/invopop/silo/attachment_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Invopop::Silo::Attachment do
+  subject(:attachment) do
+    described_class.new(
+      'id' => 'e2b7a8b0-b14b-494f-a3c0-d9b1d1e5beeb',
+      'created_at' => '2022-09-30T13:27:42.430Z',
+      'name' => 'message.pdf',
+      'hash' => 'e420fe0b8eabffb530f4aac0a3ac0d4a1245b5d78e0eec4b1d026952bb4be59e',
+      'mime' => 'application/pdf',
+      'size' => 8119,
+      'stored' => true,
+      'url' => 'https://silo.invopop.com/6HXS40DCEe2P-AJoVTqybA/4reosLFLSU-jwNmx0eW-6w/message.pdf?h=e420fe0b8eabffb5'
+    )
+  end
+
+  it 'parses url as a URI object' do
+    expect(attachment.url).to be_a(URI::HTTP)
+    expect(attachment.url.to_s).to match(/silo\.invopop\.com/)
+  end
+end

--- a/spec/invopop/silo/envelope_collection_spec.rb
+++ b/spec/invopop/silo/envelope_collection_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Invopop::Silo::EnvelopeCollection do
+  subject(:collection) do
+    described_class.new(
+      {
+        'list' => [
+          {
+            'id' => '9a4f46e9-40c8-11ed-8ff8-0268553ab26c',
+            'created_at' => '2022-09-30T14:03:04.504Z',
+            'updated_at' => '2022-09-30T14:03:04.504Z',
+            'env_schema' => 'https://gobl.org/draft-0/envelope',
+            'doc_schema' => 'https://gobl.org/draft-0/note/message',
+            'digest' => {
+              'alg' => 'sha256',
+              'val' => '6fbf3f9e2be925ba4eb79dbf71c09305c6031125004d1482204b64a4918c8ae3'
+            },
+            'draft' => true,
+            'data' => nil
+          }
+        ],
+        'limit' => 1,
+        'created_at' => '2022-09-30T14:03:04.504Z',
+        'next_created_at' => '2022-09-28T04:39:58.348Z'
+      }
+    )
+  end
+
+  it 'parses `list` as an array of Envelope objects' do
+    expect(collection.list.size).to eq(1)
+    expect(collection.list.first).to be_a(Invopop::Silo::Envelope)
+    expect(collection.list.first.id).to eq('9a4f46e9-40c8-11ed-8ff8-0268553ab26c')
+  end
+end

--- a/spec/invopop/silo/envelope_spec.rb
+++ b/spec/invopop/silo/envelope_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Invopop::Silo::Envelope do
+  subject(:envelope) do
+    described_class.new(
+      'id' => 'e875d2e3-40c2-11ed-8ff8-0268553ab26c',
+      'created_at' => '2022-09-30T13:22:18.642Z',
+      'updated_at' => '2022-09-30T13:27:42.966Z',
+      'env_schema' => 'https://gobl.org/draft-0/envelope',
+      'doc_schema' => 'https://gobl.org/draft-0/note/message',
+      'digest' => { 'alg' => 'sha256', 'val' => '34321e7ef2f62a6a9597791a10105187d197b9ee3607b53b4a50131349ae902e' },
+      'draft' => true,
+      'meta' => { 'key' => 'value' },
+      'attachments' => [
+        {
+          'id' => 'e2b7a8b0-b14b-494f-a3c0-d9b1d1e5beeb',
+          'created_at' => '2022-09-30T13:27:42.430Z',
+          'name' => 'message.pdf',
+          'hash' => 'e420fe0b8eabffb530f4aac0a3ac0d4a1245b5d78e0eec4b1d026952bb4be59e',
+          'mime' => 'application/pdf',
+          'size' => 8119,
+          'stored' => true,
+          'url' => 'https://silo.invopop.com/6HXS40DCEe2P-AJoVTqybA/4reosLFLSU-jwNmx0eW-6w/message.pdf?h=e420fe0b8eabffb5'
+        }
+      ],
+      'data' => {
+        '$schema' => 'https://gobl.org/draft-0/envelope',
+        'head' => {
+          'uuid' => 'e875d2e3-40c2-11ed-8ff8-0268553ab26c',
+          'dig' => { 'alg' => 'sha256', 'val' => '34321e7ef2f62a6a9597791a10105187d197b9ee3607b53b4a50131349ae902e' },
+          'draft' => true
+        },
+        'doc' => {
+          '$schema' => 'https://gobl.org/draft-0/note/message',
+          'content' => 'Hello world!'
+        }
+      }
+    )
+  end
+
+  it 'parses times as Time objects' do
+    expect(envelope.created_at).to be_a(Time)
+    expect(envelope.updated_at).to be_a(Time)
+  end
+
+  it 'parses `meta` as a GOBL::Meta object' do
+    expect(envelope.meta).to be_a(GOBL::Org::Meta)
+    expect(envelope.meta['key']).to eq('value')
+  end
+
+  it 'parses `draft` as a boolean' do
+    expect(envelope.draft).to be(true)
+  end
+
+  it 'parses `data` as a GOBL::Envelope' do
+    expect(envelope.data).to be_a(GOBL::Envelope)
+    expect(envelope.data.extract.content).to eq('Hello world!')
+  end
+
+  it 'parses `attachments` as an array of Attachment objects' do
+    expect(envelope.attachments.size).to be(1)
+    expect(envelope.attachments.first).to be_a(Invopop::Silo::Attachment)
+    expect(envelope.attachments.first.name).to eq('message.pdf')
+  end
+end

--- a/spec/invopop/silo/envelopes_spec.rb
+++ b/spec/invopop/silo/envelopes_spec.rb
@@ -8,15 +8,16 @@ RSpec.describe Invopop::Silo::Envelopes do
                          responding: { list: [{ id: '123' }, { id: '234' }] }
 
     response = client.silo.envelopes.fetch
-    expect(response).to eq({ 'list' => [{ 'id' => '123' }, { 'id' => '234' }] })
+    expect(response.list.size).to eq(2)
+    expect(response.list.first.id).to eq('123')
   end
 
   it 'fetches a specific envelope' do
     stub_invopop_request :get, '/silo/v1/envelopes/123',
                          responding: { id: '123' }
 
-    response = client.silo.envelopes('123').fetch
-    expect(response).to eq({ 'id' => '123' })
+    envelope = client.silo.envelopes('123').fetch
+    expect(envelope.id).to eq('123')
   end
 
   it 'creates an envelope' do
@@ -25,7 +26,7 @@ RSpec.describe Invopop::Silo::Envelopes do
                          responding: { id: '123' }
 
     response = client.silo.envelopes.create(data: { key: 'value' })
-    expect(response).to eq({ 'id' => '123' })
+    expect(response.id).to eq('123')
   end
 
   it 'creates an envelope from a GOBL document' do
@@ -37,7 +38,7 @@ RSpec.describe Invopop::Silo::Envelopes do
                          responding: { id: '123' }
 
     response = client.silo.envelopes.create(data: document)
-    expect(response).to eq({ 'id' => '123' })
+    expect(response.id).to eq('123')
   end
 
   it 'creates an envelope giving its ID' do
@@ -46,7 +47,7 @@ RSpec.describe Invopop::Silo::Envelopes do
                          responding: { id: '123' }
 
     response = client.silo.envelopes('123').create(data: { key: 'value' })
-    expect(response).to eq({ 'id' => '123' })
+    expect(response.id).to eq('123')
   end
 
   it 'updates an envelope' do
@@ -55,6 +56,6 @@ RSpec.describe Invopop::Silo::Envelopes do
                          responding: { id: '123' }
 
     response = client.silo.envelopes('123').update(data: { key: 'value' })
-    expect(response).to eq({ 'id' => '123' })
+    expect(response.id).to eq('123')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'bundler/setup'
-require 'gobl'
-
 require_relative 'support/stub_helpers'
 require_relative 'support/auth_helpers'
 


### PR DESCRIPTION
* This PR makes the the `Silo::Envelopes` resource return specific data structs (`Envelope`, `EnvelopeCollection` and `Attachment`) rather than unstructured JSON parsed data as until now.
* The new data structs, in turn, contain properties using GOBL types that are properly casted.
* Other structs for the rest of resources will be added in following PRs.