### PR TITLE
Fetch `gobl` from rubygems as a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-# TODO: `gobl` is now a runtime dependency of the gem. This entry needs to be moved to the
-# gemspec as soon as `gobl.ruby` is published to rubygems
-gem 'gobl', github: 'invopop/gobl.ruby', branch: 'main'
-
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 gem 'rubocop', '~> 1.21'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,9 @@
-GIT
-  remote: https://github.com/invopop/gobl.ruby.git
-  revision: 20817bad42107bc893c71c85d6a3ec1339cb9e56
-  branch: main
-  specs:
-    gobl (0.1.0)
-      activesupport (~> 6.1)
-      dry-files (~> 0.1.0)
-      dry-struct (~> 1.4.0)
-      dry-types (~> 1.5.1)
-      json (~> 2.6.1)
-      zeitwerk (~> 2.5.1)
-
 PATH
   remote: .
   specs:
     invopop (0.1.0)
       faraday (~> 2.5)
+      gobl (~> 0.1.3)
       hashme (~> 0.2.6)
 
 GEM
@@ -59,6 +47,13 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.0)
+    gobl (0.1.3)
+      activesupport (~> 6.1)
+      dry-files (~> 0.1.0)
+      dry-struct (~> 1.4.0)
+      dry-types (~> 1.5.1)
+      json (~> 2.6.1)
+      zeitwerk (~> 2.5.1)
     hashdiff (1.0.1)
     hashme (0.2.6)
       activemodel (>= 4.0)
@@ -120,7 +115,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  gobl!
   invopop!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/invopop.gemspec
+++ b/invopop.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'faraday', '~> 2.5'
+  spec.add_dependency 'gobl', '~> 0.1.3'
   spec.add_dependency 'hashme', '~> 0.2.6'
 end

--- a/lib/invopop/extensions/gobl.rb
+++ b/lib/invopop/extensions/gobl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-raise 'The `gobl` library version has changed. Review if this extension still applies' if GOBL::VERSION != '0.1.0'
+raise 'The `gobl` library version has changed. Review if this extension still applies' if GOBL::VERSION != '0.1.3'
 
 # Temporary extensions for the `gobl` gem. To be removed when the library supports them.
 module GOBL


### PR DESCRIPTION
* Minuscule PR to fetch the `gobl` library from RubyGems as a runtime dependency declared in the gemspec