### PR TITLE
Custom error classes for improved error handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
+  SuggestExtensions: false
 
 Metrics/AbcSize:
   Max: 55

--- a/lib/invopop.rb
+++ b/lib/invopop.rb
@@ -6,6 +6,8 @@ require 'hashme'
 
 require_relative 'invopop/client'
 require_relative 'invopop/connection'
+require_relative 'invopop/connection/error_manager'
+require_relative 'invopop/error'
 require_relative 'invopop/namespace'
 require_relative 'invopop/resource'
 require_relative 'invopop/silo'

--- a/lib/invopop/connection.rb
+++ b/lib/invopop/connection.rb
@@ -43,6 +43,7 @@ module Invopop
       Faraday.new(options) do |f|
         f.response :json
         f.request :json
+        f.use Invopop::Connection::ErrorManager
       end
     end
   end

--- a/lib/invopop/connection/error_manager.rb
+++ b/lib/invopop/connection/error_manager.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Invopop
+  class Connection
+    # Faraday Middleware responsible for raising `Invopop::Error`s
+    class ErrorManager < Faraday::Middleware
+      def call(env)
+        super
+      rescue Faraday::ConnectionFailed, Faraday::SSLError, Faraday::TimeoutError => e
+        raise Invopop::ConnectionError, e
+      rescue Faraday::Error
+        raise Invopop::Error, e
+      end
+
+      def on_complete(env)
+        case env[:status]
+        when 400..499
+          raise Invopop::ClientError, env
+        when 500..599
+          raise Invopop::ServerError, env
+        end
+      end
+    end
+  end
+end

--- a/lib/invopop/error.rb
+++ b/lib/invopop/error.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Invopop
+  # Base class for any error happening when making requests to the Invopop API
+  class Error < StandardError; end
+
+  # Raised in the case of a connection error (e.g. network, SSL, timeout)
+  class ConnectionError < Error; end
+
+  # Base class for failed HTTP responses from the Invopop API
+  class ResponseError < Error
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+      super message_from_response
+    end
+
+    def response_status
+      response[:status]
+    end
+
+    def response_headers
+      response[:headers]
+    end
+
+    def response_body
+      response[:body]
+    end
+
+    private
+
+    def message_from_response
+      "The server responded with status #{response_status}: #{response_body}"
+    end
+  end
+
+  # Raised in the case of a 4xx response
+  class ClientError < ResponseError; end
+
+  # Raised in the case of a 5xx response
+  class ServerError < ResponseError; end
+end

--- a/spec/invopop/error_spec.rb
+++ b/spec/invopop/error_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Invopop::Error do
+  let(:client) { Invopop::Client.new(access_token: test_token) }
+
+  it 'is raised when there are client errors' do
+    stub_invopop_request(:get, '/utils/v1/ping').to_return(status: 402)
+
+    expect { client.utils.ping.fetch }.to raise_error Invopop::ClientError, /402/
+  end
+
+  it 'is raised when there are server errors' do
+    stub_invopop_request(:get, '/utils/v1/ping').to_return(status: 500)
+
+    expect { client.utils.ping.fetch }.to raise_error Invopop::ServerError, /500/
+  end
+
+  it 'is raised when there are connection errors' do
+    stub_invopop_request(:get, '/utils/v1/ping').to_timeout
+
+    expect { client.utils.ping.fetch }.to raise_error Invopop::ConnectionError
+  end
+
+  it 'is raised when there are other Faraday errors' do
+    stub_invopop_request(:get, '/utils/v1/ping').to_raise Faraday::Error
+
+    expect { client.utils.ping.fetch }.to raise_error described_class
+  end
+end

--- a/spec/support/stub_helpers.rb
+++ b/spec/support/stub_helpers.rb
@@ -4,16 +4,22 @@ require 'webmock/rspec'
 
 RSpec.shared_context 'with stub helpers' do
   def stub_invopop_request(method, path, responding: nil, with_body: nil, with_query: nil)
-    stub_request(method, URI.join('https://api.invopop.com', path))
-      .with(
-        headers: { authorization: "Bearer #{test_token}" },
-        query: with_query,
-        body: with_body&.to_json
-      )
-      .to_return(
+    stub = stub_request(method, URI.join('https://api.invopop.com', path))
+
+    stub.with(
+      headers: { authorization: "Bearer #{test_token}" },
+      query: with_query,
+      body: with_body&.to_json
+    )
+
+    if responding
+      stub.to_return(
         body: responding.to_json,
         headers: { content_type: 'application/json' }
       )
+    end
+
+    stub
   end
 end
 


### PR DESCRIPTION
* This PR adds a basic set of custom error classes that are raised when API requests fail for any reason
* The purpose of these changes is providing users of the library with a simple mechanism to handle errors while abstracting them from the underlying library (Faraday)