### PR TITLE
Add support for query params in non-GET requests

### DIFF
--- a/lib/invopop/connection.rb
+++ b/lib/invopop/connection.rb
@@ -8,20 +8,26 @@ module Invopop
       self.access_token = access_token
     end
 
-    def get(path, *params)
-      faraday.get(path, *params).body
+    def get(path, params = {})
+      faraday.get(path, params).body
     end
 
-    def post(path, body)
-      faraday.post(path, body).body
+    def post(path, body, params = {})
+      faraday.post(path, body) do |req|
+        req.params = params
+      end.body
     end
 
-    def put(path, body)
-      faraday.put(path, body).body
+    def put(path, body, params = {})
+      faraday.put(path, body) do |req|
+        req.params = params
+      end.body
     end
 
-    def patch(path, body)
-      faraday.patch(path, body).body
+    def patch(path, body, params = {})
+      faraday.patch(path, body) do |req|
+        req.params = params
+      end.body
     end
 
     private

--- a/lib/invopop/resource.rb
+++ b/lib/invopop/resource.rb
@@ -14,8 +14,8 @@ module Invopop
 
     attr_accessor :conn, :parent_fragment, :id
 
-    def fetch(*params)
-      data = conn.get(path, *params)
+    def fetch(params = {})
+      data = conn.get(path, params)
 
       if single_resource?
         build_struct(data)
@@ -24,18 +24,18 @@ module Invopop
       end
     end
 
-    def create(body)
+    def create(body, params = {})
       data = if single_resource?
-               conn.put(path, body)
+               conn.put(path, body, params)
              else
-               conn.post(path, body)
+               conn.post(path, body, params)
              end
 
       build_struct(data)
     end
 
-    def update(body)
-      data = conn.patch(path, body)
+    def update(body, params = {})
+      data = conn.patch(path, body, params)
 
       build_struct(data)
     end

--- a/spec/invopop/transform/jobs_spec.rb
+++ b/spec/invopop/transform/jobs_spec.rb
@@ -40,4 +40,14 @@ RSpec.describe Invopop::Transform::Jobs do
     response = client.transform.jobs.create(workflow_id: 234, data: document)
     expect(response.id).to eq('123')
   end
+
+  it 'creates a job waiting for the response' do
+    stub_invopop_request :post, 'transform/v1/jobs',
+                         with_query: { wait: true },
+                         with_body: { workflow_id: 234, envelope_id: 345 },
+                         responding: { id: '123' }
+
+    response = client.transform.jobs.create({ workflow_id: 234, envelope_id: 345 }, wait: true)
+    expect(response.id).to eq('123')
+  end
 end


### PR DESCRIPTION
* This PR adds support for query params in PUT, POST and PATCH requests
* In practical terms, these changes allow to use the `wait` parameter when creating a job