### PR TITLE
Constrain request methods to supported body params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
 
+Lint/UselessMethodDefinition: # This raises with useful method definitions (e.g. when the signature changes in an overriden method)
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 55
 

--- a/lib/invopop/silo/envelopes.rb
+++ b/lib/invopop/silo/envelopes.rb
@@ -5,10 +5,20 @@ module Invopop
     # Resource that represent envelopes in the silo, that is, content entries in the
     # Invopop account.
     class Envelopes < Resource
-      public :fetch, :create, :update
-
       def uri_fragment
         '/envelopes'
+      end
+
+      def fetch
+        super
+      end
+
+      def create(data:)
+        super
+      end
+
+      def update(data:)
+        super
       end
 
       def build_struct(data)

--- a/lib/invopop/transform/jobs.rb
+++ b/lib/invopop/transform/jobs.rb
@@ -5,14 +5,23 @@ module Invopop
     # Resource that represents jobs in the Invopop account, that is, instances of workflow
     # executions.
     class Jobs < Resource
-      public :fetch, :create
-
       def uri_fragment
         '/jobs'
       end
 
       def build_struct(data)
         Job.new(data)
+      end
+
+      def fetch
+        super
+      end
+
+      def create(workflow_id:, envelope_id: nil, data: nil, wait: nil)
+        super(
+          { workflow_id: workflow_id, envelope_id: envelope_id, data: data }.compact,
+          { wait: wait }.compact
+        )
       end
     end
   end

--- a/lib/invopop/utils/ping.rb
+++ b/lib/invopop/utils/ping.rb
@@ -4,10 +4,12 @@ module Invopop
   class Utils
     # Resource representing a ping to the Invopop API. To use for testing connectivity.
     class Ping < Resource
-      public :fetch
-
       def uri_fragment
         '/ping'
+      end
+
+      def fetch
+        super
       end
     end
   end

--- a/lib/invopop/utils/uuid.rb
+++ b/lib/invopop/utils/uuid.rb
@@ -4,10 +4,12 @@ module Invopop
   class Utils
     # Resource that represent random UUIDs.
     class UUID < Resource
-      public :fetch
-
       def uri_fragment
         '/uuid'
+      end
+
+      def fetch(version: nil)
+        super({ v: version }.compact)
       end
     end
   end

--- a/spec/invopop/transform/jobs_spec.rb
+++ b/spec/invopop/transform/jobs_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Invopop::Transform::Jobs do
                          with_body: { workflow_id: 234, envelope_id: 345 },
                          responding: { id: '123' }
 
-    response = client.transform.jobs.create({ workflow_id: 234, envelope_id: 345 }, wait: true)
+    response = client.transform.jobs.create(workflow_id: 234, envelope_id: 345, wait: true)
     expect(response.id).to eq('123')
   end
 end

--- a/spec/invopop/utils/uuid_spec.rb
+++ b/spec/invopop/utils/uuid_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Invopop::Utils::UUID do
                          with_query: { v: '1' },
                          responding: { 'uuid' => '123', 'version' => '1' }
 
-    response = client.utils.uuid.fetch(v: 1)
+    response = client.utils.uuid.fetch(version: 1)
     expect(response).to eq('uuid' => '123', 'version' => '1')
   end
 end


### PR DESCRIPTION
* This PR ensures the resource request methods (`fetch`, `create`, `update`) only allow in their signatures the query and body parameters supported by the corresponding API endpoint.