### PR TITLE
Add support for creating corrections in the silo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ message = GOBL::Note::Message.new(content: 'Hello world!')
 document = GOBL::Schema::Object.embed(message)
 invopop.silo.entries.create(data: document) #=> #<Invopop::Silo::Entry…>
 
+# Create a corrective GOBL document in the silo
+invopop.silo.entries.create(
+  previous_id: '61371ed5-56ca-11ee-9d41-12d59aa0e29f',
+  correct: GOBL::Bill::CorrectionOptions.new(credit: true)
+) #=> #<Invopop::Silo::Entry…>
+
 # Update a GOBL document
 invopop.silo.entries("658c4ea1-9264-11ed-958a-52e43541c80c").update(data: document) #=> #<Invopop::Silo::Entry…>
 

--- a/lib/invopop/silo/entries.rb
+++ b/lib/invopop/silo/entries.rb
@@ -13,8 +13,8 @@ module Invopop
         super
       end
 
-      def create(data:)
-        super
+      def create(data: nil, previous_id: nil, correct: nil)
+        super({ data: data, previous_id: previous_id, correct: correct }.compact)
       end
 
       def update(data:)

--- a/spec/invopop/silo/entries_spec.rb
+++ b/spec/invopop/silo/entries_spec.rb
@@ -50,6 +50,18 @@ RSpec.describe Invopop::Silo::Entries do
     expect(response.id).to eq('123')
   end
 
+  it 'creates a correction' do
+    previous_id = 'aef83ed6-683b-11ee-8c99-0242ac120002'
+    correction = GOBL::Bill::CorrectionOptions.new(reason: 'Correction reason')
+
+    stub_invopop_request :put, 'silo/v1/entries/123',
+                         with_body: { previous_id: previous_id, correct: correction.as_json },
+                         responding: { id: '123' }
+
+    response = client.silo.entries('123').create(previous_id: previous_id, correct: correction)
+    expect(response.id).to eq('123')
+  end
+
   it 'updates an envelope' do
     stub_invopop_request :patch, '/silo/v1/entries/123',
                          with_body: { data: { key: 'value' } },


### PR DESCRIPTION
* API reference: https://docs.invopop.com/reference/silo/entries/create-an-entry-put
* GOBL reference: https://docs.gobl.org/draft-0/bill/correction_options